### PR TITLE
资源文件上传添加HDFS kerberos授权

### DIFF
--- a/hera-core/src/main/java/com/dfire/core/job/UploadLocalFileJob.java
+++ b/hera-core/src/main/java/com/dfire/core/job/UploadLocalFileJob.java
@@ -24,6 +24,11 @@ public class UploadLocalFileJob extends ProcessJob {
     @Override
     public List<String> getCommandList() {
         List<String> commands = new ArrayList<>();
+        String keytab = HeraGlobalEnv.kerberosKeytabPath;
+        String principal = HeraGlobalEnv.kerberosPrincipal;
+        if(StringUtils.isNotBlank(keytab)&&StringUtils.isNotBlank(principal)){
+            commands.add("kinit -kt "+keytab.trim()+" "+principal.trim());
+        }
         commands.add("hadoop fs -copyFromLocal " + localPath + " " + hadoopPath);
         return commands;
     }


### PR DESCRIPTION
如果kerberos keytab  和principal 没有配置，则不执行授权命令