### PR TITLE
添加HDFS存储资源文件上传下载的kerberos授权

### DIFF
--- a/hera-admin/src/main/resources/application.yml
+++ b/hera-admin/src/main/resources/application.yml
@@ -80,6 +80,9 @@ hera:
   alarmEnv: daily,dev,pre,publish # 设置允许哪些环境开启告警，多个用,分开，默认全部环境
   sudoUser: true  #是否要使用sudo -u 切换账号(即启动多租户功能)
   version: 2.3
+  kerberos:
+    keytabpath: hdfs.keytab   #kerberos认证keytab文件,如果hadoop 集群无需kerberos授权，则不填
+    principal: hdfsprincipal    #kerberos认证principal,如果hadoop 集群无需kerberos授权，则不填
   job:
     shell:
       bin: sh

--- a/hera-core/src/main/java/com/dfire/core/job/DownloadHadoopFileJob.java
+++ b/hera-core/src/main/java/com/dfire/core/job/DownloadHadoopFileJob.java
@@ -29,6 +29,13 @@ public class DownloadHadoopFileJob extends ProcessJob {
     @Override
     public List<String> getCommandList() {
         List<String> commands = new ArrayList<>();
+		//获取hdfs kerberos keytab
+		String keytab = HeraGlobalEnv.kerberosKeytabPath;
+		//获取hdfs kerberos principal
+        String principal = HeraGlobalEnv.kerberosPrincipal;
+        if(StringUtils.isNotBlank(keytab)&&StringUtils.isNotBlank(principal)){
+            commands.add("kinit -kt "+keytab.trim()+" "+principal.trim());
+        }
         if (HeraGlobalEnv.isEmrJob()) {
             File file = new File(localPath);
             //创建文件  + copyToLocal 放在一行

--- a/hera-core/src/main/java/com/dfire/core/job/DownloadHadoopFileJob.java
+++ b/hera-core/src/main/java/com/dfire/core/job/DownloadHadoopFileJob.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.dfire.common.constants.Constants;
 import com.dfire.config.HeraGlobalEnv;
 import com.dfire.logs.MonitorLog;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -29,9 +30,9 @@ public class DownloadHadoopFileJob extends ProcessJob {
     @Override
     public List<String> getCommandList() {
         List<String> commands = new ArrayList<>();
-		//获取hdfs kerberos keytab
-		String keytab = HeraGlobalEnv.kerberosKeytabPath;
-		//获取hdfs kerberos principal
+        //获取hdfs kerberos keytab
+        String keytab = HeraGlobalEnv.kerberosKeytabPath;
+        //获取hdfs kerberos principal
         String principal = HeraGlobalEnv.kerberosPrincipal;
         if(StringUtils.isNotBlank(keytab)&&StringUtils.isNotBlank(principal)){
             commands.add("kinit -kt "+keytab.trim()+" "+principal.trim());

--- a/hera-core/src/main/java/com/dfire/core/job/UploadLocalFileJob.java
+++ b/hera-core/src/main/java/com/dfire/core/job/UploadLocalFileJob.java
@@ -2,6 +2,7 @@ package com.dfire.core.job;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author: <a href="mailto:lingxiao@2dfire.com">凌霄</a>
@@ -24,9 +25,9 @@ public class UploadLocalFileJob extends ProcessJob {
     @Override
     public List<String> getCommandList() {
         List<String> commands = new ArrayList<>();
-		//获取hdfs kerberos keytab
-		String keytab = HeraGlobalEnv.kerberosKeytabPath;
-		//获取hdfs kerberos principal
+		    //获取hdfs kerberos keytab
+		    String keytab = HeraGlobalEnv.kerberosKeytabPath;
+		    //获取hdfs kerberos principal
         String principal = HeraGlobalEnv.kerberosPrincipal;
         if(StringUtils.isNotBlank(keytab)&&StringUtils.isNotBlank(principal)){
             commands.add("kinit -kt "+keytab.trim()+" "+principal.trim());

--- a/hera-core/src/main/java/com/dfire/core/job/UploadLocalFileJob.java
+++ b/hera-core/src/main/java/com/dfire/core/job/UploadLocalFileJob.java
@@ -24,6 +24,13 @@ public class UploadLocalFileJob extends ProcessJob {
     @Override
     public List<String> getCommandList() {
         List<String> commands = new ArrayList<>();
+		//获取hdfs kerberos keytab
+		String keytab = HeraGlobalEnv.kerberosKeytabPath;
+		//获取hdfs kerberos principal
+        String principal = HeraGlobalEnv.kerberosPrincipal;
+        if(StringUtils.isNotBlank(keytab)&&StringUtils.isNotBlank(principal)){
+            commands.add("kinit -kt "+keytab.trim()+" "+principal.trim());
+        }
         commands.add("hadoop fs -copyFromLocal " + localPath + " " + hadoopPath);
         return commands;
     }


### PR DESCRIPTION
hera:
    kerberos:
        keytabpath: hdfs.keytab   #kerberos认证keytab文件,如果hadoop 集群无需kerberos授权，则不填
        principal: hdfsprincipal    #kerberos认证principal,如果hadoop 集群无需kerberos授权，则不填

hdfs.keytab、hdfsprincipal  为KDC服务生产
注意keytab 文件需要有执行上传用户的可读权限