### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ jdk:
 install: mvn install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
 #script: mvn test
 script: mvn clean package -Pdev
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.