### PR TITLE
生成action优化

### DIFF
--- a/hera-core/src/main/java/com/dfire/core/event/listenter/HeraAddJobListener.java
+++ b/hera-core/src/main/java/com/dfire/core/event/listenter/HeraAddJobListener.java
@@ -32,19 +32,10 @@ public class HeraAddJobListener extends AbstractListener {
             HeraJobMaintenanceEvent maintenanceEvent = (HeraJobMaintenanceEvent) mvcEvent.getApplicationEvent();
             if (mvcEvent.getType() == Events.UpdateActions) {
                 Long actionId = maintenanceEvent.getId();
-                boolean exist = false;
-                for (AbstractHandler handler : masterContext.getDispatcher().getJobHandlers()) {
-                    if (handler instanceof JobHandler) {
-                        JobHandler jobHandler = (JobHandler) handler;
-                        if (jobHandler.getActionId().equals(actionId)) {
-                            exist = true;
-                            break;
-                        }
-                    }
-                }
+                boolean exist = masterContext.getDispatcher().getJobHandlers().containsKey(actionId);
                 if (!exist) {
                     JobHandler handler = new JobHandler(actionId, master, masterContext);
-                    masterContext.getDispatcher().addJobHandler(handler);
+                    handler = masterContext.getDispatcher().addJobHandler(handler);
                     handler.handleEvent(new ApplicationEvent(Events.Initialize));
                     mvcEvent.setCancelled(true);
                     ScheduleLog.info("schedule add job with actionId:" + actionId);

--- a/hera-core/src/main/java/com/dfire/core/netty/master/schedule/RerunJobInit.java
+++ b/hera-core/src/main/java/com/dfire/core/netty/master/schedule/RerunJobInit.java
@@ -60,8 +60,9 @@ public class RerunJobInit extends ScheduledChore {
                 Map<Integer, List<HeraAction>> idMap = new HashMap<>(8);
                 Map<Integer, HeraJob> jobMap = new HashMap<>(8);
                 cronDate = ActionUtil.getActionVersionPrefix(startTime.getTime());
+                heraJobs = master.topologicalSort(heraJobs);
                 master.generateScheduleJobAction(heraJobs, cronDate, actionMap, nowAction, idMap, jobMap);
-                jobMap.values().forEach(job -> master.generateDependJobAction(jobMap, job, actionMap, nowAction, idMap));
+                jobMap.values().forEach(job -> master.generateDependJobAction(job, actionMap, nowAction, idMap));
                 startTime.add(Calendar.DAY_OF_YEAR, 1);
                 for (Long aLong : actionMap.keySet()) {
                     if (Objects.equals(ActionUtil.getJobId(String.valueOf(aLong)), rerunVo.getJobId()) && aLong >= startAction && aLong <= endAction) {


### PR DESCRIPTION
1、使用List存储，遍历时间是O(n)，时长会随着内存中实例的增加而增加，而且生成action的时候会使用 contains 方法判断内存中是不是有这个实例，所以改了存储结构，使用Map
2、依赖任务生成实例，在依赖层级非常多的情况下，使用深度遍历，递归方法非常耗时，所以改成使用广度遍历，先进行一次拓扑排序，最上层的任务一定最先生成实例，就不需要递归的去生成依赖任务的实例